### PR TITLE
Rework block display name truncation

### DIFF
--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
@@ -13,6 +13,7 @@ import net.minecraft.block.*;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
@@ -296,6 +297,8 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
         }
     }
 
+    private static String cachedBlockName;
+    private static String cachedTruncatedBlockName;
     /**
      * Shows standard information about a block based on the probe configuration and mode.
      * This method handles different types of blocks and their display in the probe info.
@@ -345,18 +348,43 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
             if (Tools.show(mode, config.getShowModName())) {
                 String blockDisplayName = pickBlock.getDisplayName();
 
-                // Calculate available width for text
-                Minecraft mc = Minecraft.getMinecraft();
-                ScaledResolution resolution = new ScaledResolution(mc);
-                int screenWidth = resolution.getScaledWidth();
-                int availableWidth = screenWidth / 4;  // adjust based on layout
+                if (ConfigSetup.getBlockNameMaxWidth() != 0) {
+                    // Calculate available width for text
+                    FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
+                    ScaledResolution resolution = new ScaledResolution(Minecraft.getMinecraft());
+                    int screenWidth = resolution.getScaledWidth();
+                    int availableWidth = (int)(screenWidth * ConfigSetup.getBlockNameMaxWidth());
 
-                // Estimate max characters based on font width and available width
-                int maxChars = availableWidth / mc.fontRenderer.getCharWidth('A'); // assuming average width of 'A'
+                    // String truncation
+                    if (blockDisplayName.equals(cachedBlockName))
+                        blockDisplayName = cachedTruncatedBlockName;
+                    else if (fontRenderer.getStringWidth(blockDisplayName) > availableWidth) {
+                        int charWidth = fontRenderer.getCharWidth(blockDisplayName.charAt(0));
+                        // Estimate
+                        int index = availableWidth / charWidth - 1;
+                        index = Math.max(index, 0);
+                        String truncated = null;
+                        boolean quit = false;
+                        // This loop usually runs 2-4 times
+                        while (!quit) {
+                            truncated = blockDisplayName.substring(0, index);
+                            int width = fontRenderer.getStringWidth(truncated);
+                            int nextWidth = fontRenderer.getStringWidth(blockDisplayName.substring(0, index + 1));
 
-                // Truncate if needed
-                if (blockDisplayName.length() > maxChars) {
-                    blockDisplayName = blockDisplayName.substring(0, maxChars - 3) + "...";
+                            if ((width <= availableWidth && nextWidth > availableWidth) || width == availableWidth)
+                                quit = true;
+                            else if (width > availableWidth)
+                                index /= 2;
+                            else
+                                index++;
+                        }
+                        blockDisplayName = truncated + "...";
+                        cachedBlockName = blockDisplayName;
+                        cachedTruncatedBlockName = blockDisplayName;
+                    } else {
+                        cachedBlockName = blockDisplayName;
+                        cachedTruncatedBlockName = blockDisplayName;
+                    }
                 }
 
                 probeInfo.horizontal()
@@ -364,7 +392,6 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
                         .vertical()
                         .text(NAME + blockDisplayName)
                         .text(MODNAME + modid);
-
             } else {
                 probeInfo.horizontal(probeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER))
                         .item(pickBlock)

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
@@ -378,8 +378,8 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
                             else
                                 index++;
                         }
-                        blockDisplayName = truncated + "...";
                         cachedBlockName = blockDisplayName;
+                        blockDisplayName = truncated + "...";
                         cachedTruncatedBlockName = blockDisplayName;
                     } else {
                         cachedBlockName = blockDisplayName;

--- a/src/main/java/mcjty/theoneprobe/config/ConfigSetup.java
+++ b/src/main/java/mcjty/theoneprobe/config/ConfigSetup.java
@@ -67,7 +67,6 @@ public class ConfigSetup {
     private static Set<ResourceLocation> dontSendNBTSet = null;
 
     public static float probeDistance = 6;
-    public static int probeMaxChars = 13;
     public static boolean showLiquids = false;
     public static boolean showDebugUUID = false;
     public static boolean isVisible = true;
@@ -115,6 +114,8 @@ public class ConfigSetup {
             "theoneprobe.harvestlevel.vibranium"
     };
 
+    private static float blockNameMaxWidth = 0.0f;
+
     public static Map<TextStyleClass, String> defaultTextStyleClasses = new HashMap<>();
     public static Map<TextStyleClass, String> textStyleClasses;
 
@@ -153,7 +154,6 @@ public class ConfigSetup {
     }
 
     public static void init(Configuration cfg) {
-        probeMaxChars = cfg.getInt("probeMaxChars", CATEGORY_THEONEPROBE, probeMaxChars, 1,100, "The max length of a itemstack's display name to show");
         showProbeNoteGUI = cfg.getBoolean("showProbeNoteGUI", CATEGORY_THEONEPROBE + "." + SUBCATEGORY_SHOW, showProbeNoteGUI,"Show probes note screen on right-click");
         showProbeConfigGUI = cfg.getBoolean("showProbeConfigGUI", CATEGORY_THEONEPROBE + "." + SUBCATEGORY_SHOW, showProbeConfigGUI,"Show probes config screen on right-click");
         probeNoteBlock = cfg.getString("probeNoteBlock", CATEGORY_THEONEPROBE, probeNoteBlock,"What block should be used in inside the probe note example");
@@ -241,6 +241,7 @@ public class ConfigSetup {
         showBreakProgress = cfg.getInt("showBreakProgress", CATEGORY_CLIENT, showBreakProgress, 0, 2, "0 means don't show break progress, 1 is show as bar, 2 is show as text");
         harvestStyleVanilla = cfg.getBoolean("harvestStyleVanilla", CATEGORY_CLIENT, harvestStyleVanilla, "true means shows harvestability with vanilla style icons");
         harvestLevels = cfg.getStringList("harvestLevels", CATEGORY_CLIENT, harvestLevels, "The language translation keys to use when showing harvest levels");
+        blockNameMaxWidth = cfg.getFloat("blockNameMaxWidth", CATEGORY_CLIENT, blockNameMaxWidth, 0.0f, 1.0f, "The max displaying width of a block name, 0.0 is no limit, otherwise represents the percentage with respect to the whole screen");
 
         Map<TextStyleClass, String> newformat = new HashMap<>();
         for (TextStyleClass styleClass : textStyleClasses.keySet()) {
@@ -315,6 +316,10 @@ public class ConfigSetup {
         return harvestLevels;
     }
 
+    public static float getBlockNameMaxWidth(){
+        return blockNameMaxWidth;
+    }
+
     public static boolean getHarvestStyleVanilla(){
         return harvestStyleVanilla;
     }
@@ -330,9 +335,6 @@ public class ConfigSetup {
     }
     public static boolean getShowProbeNoteGUI(){
         return showProbeNoteGUI;
-    }
-    public static int getProbeMaxChars(){
-        return probeMaxChars;
     }
     public static int getProbeButtonColor(){
         return probeButtonColor;


### PR DESCRIPTION
- Accurate string truncation
- Create a cache to avoid redundant truncation
- Replace probeMaxChars by blockNameMaxWidth in config (disabled by default)