### PR TITLE
Fix Compat Issues due to String Network Refactor

### DIFF
--- a/src/main/java/mcjty/theoneprobe/network/NetworkTools.java
+++ b/src/main/java/mcjty/theoneprobe/network/NetworkTools.java
@@ -83,9 +83,15 @@ public class NetworkTools {
         }
     }
 
+    /**
+     * Writes a UTF-8 encoded String to the given ByteBuf. Can handle null strings.
+     *
+     * @param buf The ByteBuf to write to.
+     * @param str The String to write.
+     */
     public static void writeStringCompact(ByteBuf buf, String str) {
         if (str == null) {
-            writeVarInt(buf, 0); // length = 0 means empty/null
+            writeVarInt(buf, -1); // -1 = null
             return;
         }
 
@@ -94,14 +100,68 @@ public class NetworkTools {
         buf.writeBytes(bytes);
     }
 
+    /**
+     * Reads a UTF-8 encoded String from the given ByteBuf.
+     *
+     * @param buf The ByteBuf to read from.
+     * @return The String read from the buffer, or null if the length was -1, or an empty string if the length was 0.
+     */
     public static String readStringCompact(ByteBuf buf) {
         int length = readVarInt(buf);
+        if (length == -1) return null;
         if (length == 0) return "";
         byte[] bytes = new byte[length];
         buf.readBytes(bytes);
         return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
     }
 
+    /**
+     * Writes a UTF-8 encoded String to the given ByteBuf. Can handle null strings.<br>
+     * For compat only. Use {@link NetworkTools#writeStringCompact} instead.
+     *
+     * @param buf The ByteBuf to write to.
+     * @param str The String to write.
+     */
+    @Deprecated
+    public static void writeString(ByteBuf buf, String str) {
+        writeStringCompact(buf, str);
+    }
+
+    /**
+     * Writes a UTF-8 encoded String to the given ByteBuf. Can handle null strings.<br>
+     * For compat only. Use {@link NetworkTools#writeStringCompact} instead.
+     *
+     * @param buf The ByteBuf to write to.
+     * @param str The String to write.
+     */
+    @Deprecated
+    public static void writeStringUTF8(ByteBuf buf, String str) {
+        writeStringCompact(buf, str);
+    }
+
+    /**
+     * Reads a UTF-8 encoded String from the given ByteBuf.<br>
+     * For compat only. Use {@link NetworkTools#readStringCompact} instead.
+     *
+     * @param buf The ByteBuf to read from.
+     * @return The String read from the buffer, or null if the length was -1, or an empty string if the length was 0.
+     */
+    @Deprecated
+    public static String readString(ByteBuf buf) {
+        return readStringCompact(buf);
+    }
+
+    /**
+     * Reads a UTF-8 encoded String from the given ByteBuf.<br>
+     * For compat only. Use {@link NetworkTools#readStringCompact} instead.
+     *
+     * @param buf The ByteBuf to read from.
+     * @return The String read from the buffer, or null if the length was -1, or an empty string if the length was 0.
+     */
+    @Deprecated
+    public static String readStringUTF8(ByteBuf buf) {
+        return readStringCompact(buf);
+    }
 
     /**
      * Reads a BlockPos from the given ByteBuf.


### PR DESCRIPTION
This PR fixes issues caused by https://github.com/strubium/TheOneSmeagle/commit/4e75197ab6c9191a6b3024d972058683774e08e6#diff-c5eaacb09eeae1823b5261fc42223359371f9cca0a3e260bd15b47b93bec7fe0, in which compat was broken with many mods due to the removal of the original read/write string methods in `NetworkTools`.

This PR adds those functions back (as deprecated), and restores the original distinction in the read/write string methods of null vs empty strings, in case mods depended on that behaviour. (This has only a tiny influence on packet size, which is worth it compared to potential compatibility issues)

Fixes #47 