### PR TITLE
Fix Differing Item Padding in Chest Contents

### DIFF
--- a/src/main/java/mcjty/theoneprobe/Utilities.java
+++ b/src/main/java/mcjty/theoneprobe/Utilities.java
@@ -74,7 +74,7 @@ public class Utilities {
 
         if (Tools.show(mode, Config.getRealConfig().getShowChestContentsDetailed()) && stacks.size() <= Config.showItemDetailThresshold) {
             for (ItemStack stackInSlot : stacks) {
-                vertical.horizontal(new LayoutStyle().spacing(10).alignment(ElementAlignment.ALIGN_CENTER))
+                vertical.horizontal(new LayoutStyle().spacing(8).alignment(ElementAlignment.ALIGN_CENTER))
                         .item(stackInSlot)
                         .text(TextStyleClass.INFO + stackInSlot.getDisplayName());
             }

--- a/src/main/java/mcjty/theoneprobe/Utilities.java
+++ b/src/main/java/mcjty/theoneprobe/Utilities.java
@@ -13,7 +13,6 @@ import mcjty.theoneprobe.api.ElementAlignment;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.ProbeMode;
 import mcjty.theoneprobe.api.TextStyleClass;
-import mcjty.theoneprobe.apiimpl.styles.ItemStyle;
 import mcjty.theoneprobe.apiimpl.styles.LayoutStyle;
 import mcjty.theoneprobe.config.Config;
 import net.minecraft.item.Item;
@@ -76,7 +75,7 @@ public class Utilities {
         if (Tools.show(mode, Config.getRealConfig().getShowChestContentsDetailed()) && stacks.size() <= Config.showItemDetailThresshold) {
             for (ItemStack stackInSlot : stacks) {
                 vertical.horizontal(new LayoutStyle().spacing(10).alignment(ElementAlignment.ALIGN_CENTER))
-                        .item(stackInSlot, new ItemStyle().width(16).height(16))
+                        .item(stackInSlot)
                         .text(TextStyleClass.INFO + stackInSlot.getDisplayName());
             }
         } else {


### PR DESCRIPTION
This PR stops the itemstyles from being different in expanded vs condensed chest content views.

This issue is annoying visually when transitioning between shifting and not shifting, and this is already done in TOPAddons' Storage Drawers compat. (where expanded chest views for drawers are replaced)

As the actual icon size is not changed, and only the padding around it is changed, the manual specified spacing between the icon and the item label was decreased, leading to the same resultant distance.

(Before: no icon padding + 10 specified; Now: 2 icon padding on both sides + 8 specified)

As a side effect, the aligning of the item label is also improved.

Note: this issue is also present in base TOP.

Before:

https://github.com/user-attachments/assets/6f561de2-ef2b-4e7d-8cad-f3629d30cd53

After:

https://github.com/user-attachments/assets/f75cf879-6791-4fb3-8d9c-7fbb7c50a202

