### PR TITLE
Fully Fix Fluid Name Localisation

### DIFF
--- a/src/main/java/mcjty/theoneprobe/api/IProbeInfo.java
+++ b/src/main/java/mcjty/theoneprobe/api/IProbeInfo.java
@@ -3,6 +3,7 @@ package mcjty.theoneprobe.api;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fluids.FluidStack;
 
 /**
  * Information to return to the probe. Most methods here return the same probe info
@@ -86,6 +87,11 @@ public interface IProbeInfo {
      */
     IProbeInfo itemLabel(ItemStack stack, ITextStyle style);
     IProbeInfo itemLabel(ItemStack stack);
+
+    /**
+     * A localized name of the fluidstack
+     */
+    IProbeInfo fluidLabel(FluidStack stack);
 
     /**
      * This creates a progress bar of 100 width

--- a/src/main/java/mcjty/theoneprobe/apiimpl/TheOneProbeImp.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/TheOneProbeImp.java
@@ -17,6 +17,7 @@ public class TheOneProbeImp implements ITheOneProbe {
     public static int ELEMENT_ENTITY;
     public static int ELEMENT_ICON;
     public static int ELEMENT_ITEMLABEL;
+    public static int ELEMENT_FLUIDLABEL;
 
     private final List<IProbeConfigProvider> configProviders = new ArrayList<>();
 
@@ -39,6 +40,7 @@ public class TheOneProbeImp implements ITheOneProbe {
         ELEMENT_ENTITY = TheOneProbe.theOneProbeImp.registerElementFactory(ElementEntity::new);
         ELEMENT_ICON = TheOneProbe.theOneProbeImp.registerElementFactory(ElementIcon::new);
         ELEMENT_ITEMLABEL = TheOneProbe.theOneProbeImp.registerElementFactory(ElementItemLabel::new);
+        ELEMENT_FLUIDLABEL = TheOneProbe.theOneProbeImp.registerElementFactory(ElementFluidLabel::new);
     }
 
     private int findProvider(String id) {

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/AbstractElementPanel.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/AbstractElementPanel.java
@@ -8,6 +8,7 @@ import mcjty.theoneprobe.rendering.RenderHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -98,6 +99,12 @@ public abstract class AbstractElementPanel implements IElement, IProbeInfo {
     @Override
     public IProbeInfo itemLabel(ItemStack stack) {
         children.add(new ElementItemLabel(stack));
+        return this;
+    }
+
+    @Override
+    public IProbeInfo fluidLabel(FluidStack stack) {
+        children.add(new ElementFluidLabel(stack));
         return this;
     }
 

--- a/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementFluidLabel.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/elements/ElementFluidLabel.java
@@ -1,0 +1,83 @@
+package mcjty.theoneprobe.apiimpl.elements;
+
+import io.netty.buffer.ByteBuf;
+import mcjty.theoneprobe.TheOneProbe;
+import mcjty.theoneprobe.api.IElement;
+import mcjty.theoneprobe.apiimpl.TheOneProbeImp;
+import mcjty.theoneprobe.apiimpl.client.ElementTextRender;
+import mcjty.theoneprobe.network.NetworkTools;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+public class ElementFluidLabel implements IElement {
+
+    private final String fluidName;
+    private final int amount;
+    private String translatedName;
+
+    public ElementFluidLabel(FluidStack fluid) {
+        if (fluid == null) {
+            this.fluidName = "";
+            this.amount = 0;
+        } else {
+            this.fluidName = fluid.getFluid().getName();
+            this.amount = fluid.amount;
+        }
+    }
+
+    public ElementFluidLabel(ByteBuf buf) {
+        this.fluidName = NetworkTools.readStringCompact(buf);
+        this.amount = buf.readInt();
+        this.translatedName = getTranslatedName();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        NetworkTools.writeStringCompact(buf, fluidName);
+        buf.writeInt(amount);
+    }
+
+    @Override
+    public void render(int x, int y) {
+        if (translatedName != null && !translatedName.isEmpty()) {
+            ElementTextRender.render(translatedName, x, y);
+        }
+    }
+
+    @Override
+    public int getWidth() {
+        if (translatedName != null && !translatedName.isEmpty()) {
+            return ElementTextRender.getWidth(translatedName);
+        }
+
+        return 10;
+    }
+
+    @Override
+    public int getHeight() {
+        return 10;
+    }
+
+    @Override
+    public int getID() {
+        return TheOneProbeImp.ELEMENT_FLUIDLABEL;
+    }
+
+    @SideOnly(Side.CLIENT)
+    private String getTranslatedName() {
+        if (fluidName == null || fluidName.isEmpty()) return ""; // Empty Tank
+
+        Fluid fluid = FluidRegistry.getFluid(fluidName);
+
+        if (fluid == null) {
+            // This should never happen, but just in case, return the plain fluid name
+            TheOneProbe.setup.getLogger().error("Could not find fluid with name {}", fluidName);
+            return fluidName;
+        }
+
+        return fluid.getLocalizedName(new FluidStack(fluid, amount));
+    }
+}

--- a/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
+++ b/src/main/java/mcjty/theoneprobe/apiimpl/providers/DefaultProbeInfoProvider.java
@@ -224,7 +224,9 @@ public class DefaultProbeInfoProvider implements IProbeInfoProvider {
     private void addFluidInfo(IProbeInfo probeInfo, ProbeConfig config, FluidStack fluidStack, int maxContents) {
         int contents = fluidStack == null ? 0 : fluidStack.amount;
         if (fluidStack != null) {
-            probeInfo.text(NAME + "Liquid: " + " {*" + fluidStack.getUnlocalizedName() +"*}"); //TOPFIX: Fluid container info doesn't show fluid local name when player on server.
+            probeInfo.horizontal()
+                     .text(NAME + "Liquid: ")
+                     .fluidLabel(fluidStack); //TOPFIX: Fluid container info doesn't show fluid local name when player on server.
         }
         if (config.getTankMode() == 1) {
             probeInfo.progress(contents, maxContents,


### PR DESCRIPTION
This PR fully fixes fluid name localization, which still wasn't working in some edge cases (e.g. GTMaterialFluid), due to those fluids not returning a proper translation from `getUnlocalizedName`.

To fix this, a new element has been added, which grabs the fluid directly from `FluidRegistry` to translate it properly. This is also exposed to API for addons to use.

Heavily inspired by this implementation in Labs: https://github.com/Nomi-CEu/Nomi-Labs/blob/main/src/main/java/com/nomiceu/nomilabs/integration/top/LabsFluidNameElement.java

Before:
<img width="854" height="480" alt="2025-10-11_16 38 39" src="https://github.com/user-attachments/assets/5a2225cd-31ea-47eb-ada7-d7364d09f661" />

After:
<img width="854" height="480" alt="2025-10-11_16 51 26" src="https://github.com/user-attachments/assets/c90478bc-5a4c-49c8-9289-249cbcaf4e60" />
